### PR TITLE
Opengl es 3.0

### DIFF
--- a/OpenGLAprendiendo.podspec
+++ b/OpenGLAprendiendo.podspec
@@ -1,0 +1,16 @@
+Pod::Spec.new do |s|
+  s.name                  = 'OpenGLAprendiendo'
+  s.version               = '0.0.1'
+  s.summary               = 'OpenGL C++ Triangle class to render a colorful triangle'
+  s.homepage              = 'https://github.com/rbaumbach/OpenGLAprendiendo'
+  s.license               = { :type => 'MIT', :file => 'LICENSE' }
+  s.author                = { 'Ryan Baumbach' => 'github@ryan.codes' }
+  s.source                = { :git => 'https://github.com/rbaumbach/OpenGLAprendiendo.git', :tag => s.version.to_s }
+  s.requires_arc          = true
+  s.ios.deployment_target = '11.2'
+  s.osx.deployment_target = '10.13.3'
+  s.public_header_files   = 'OpenGLAprendiendo/Triangle/*.{hpp}',
+                            'OpenGLAprendiendo/Triangle/Shaders/*.{hpp}'
+  s.source_files          = 'OpenGLAprendiendo/Triangle/*.{hpp,cpp}',
+                            'OpenGLAprendiendo/Triangle/Shaders/*.{hpp,cpp}'
+end

--- a/OpenGLAprendiendo.xcodeproj/project.pbxproj
+++ b/OpenGLAprendiendo.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		942B8F962040B0C9006AACE9 /* libGLEW.2.1.0.dylib in Copy Framework Files */ = {isa = PBXBuildFile; fileRef = 942B8F872040A923006AACE9 /* libGLEW.2.1.0.dylib */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 		9450B1A0205ADCF7007C9699 /* Triangle.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 9450B19E205ADCF7007C9699 /* Triangle.cpp */; };
 		9460B4C6204066D000DF2EE5 /* main.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 9460B4C5204066D000DF2EE5 /* main.cpp */; };
+		9476805E205D7A2500DF5323 /* ShaderConstants.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 9476805C205D7A2500DF5323 /* ShaderConstants.cpp */; };
 		94C2CE9D2059AD370087A103 /* ShaderManager.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 94C2CE9B2059AD370087A103 /* ShaderManager.cpp */; };
 		94C2CEA42059BA1F0087A103 /* vertex.glsl in Copy Resources Files */ = {isa = PBXBuildFile; fileRef = 94C2CE9F2059B0160087A103 /* vertex.glsl */; };
 		94C2CEA52059BA1F0087A103 /* fragment.glsl in Copy Resources Files */ = {isa = PBXBuildFile; fileRef = 94C2CEA02059B0220087A103 /* fragment.glsl */; };
@@ -59,6 +60,8 @@
 		9450B19F205ADCF7007C9699 /* Triangle.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = Triangle.hpp; sourceTree = "<group>"; };
 		9460B4C2204066D000DF2EE5 /* OpenGLAprendiendo */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = OpenGLAprendiendo; sourceTree = BUILT_PRODUCTS_DIR; };
 		9460B4C5204066D000DF2EE5 /* main.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = main.cpp; sourceTree = "<group>"; };
+		9476805C205D7A2500DF5323 /* ShaderConstants.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = ShaderConstants.cpp; sourceTree = "<group>"; };
+		9476805D205D7A2500DF5323 /* ShaderConstants.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = ShaderConstants.hpp; sourceTree = "<group>"; };
 		94C2CE9B2059AD370087A103 /* ShaderManager.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = ShaderManager.cpp; sourceTree = "<group>"; };
 		94C2CE9C2059AD370087A103 /* ShaderManager.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = ShaderManager.hpp; sourceTree = "<group>"; };
 		94C2CE9F2059B0160087A103 /* vertex.glsl */ = {isa = PBXFileReference; lastKnownFileType = text; path = vertex.glsl; sourceTree = "<group>"; };
@@ -124,6 +127,8 @@
 				94C2CEA02059B0220087A103 /* fragment.glsl */,
 				94C2CE9C2059AD370087A103 /* ShaderManager.hpp */,
 				94C2CE9B2059AD370087A103 /* ShaderManager.cpp */,
+				9476805C205D7A2500DF5323 /* ShaderConstants.cpp */,
+				9476805D205D7A2500DF5323 /* ShaderConstants.hpp */,
 			);
 			path = Shaders;
 			sourceTree = "<group>";
@@ -223,6 +228,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				9476805E205D7A2500DF5323 /* ShaderConstants.cpp in Sources */,
 				94C2CE9D2059AD370087A103 /* ShaderManager.cpp in Sources */,
 				9450B1A0205ADCF7007C9699 /* Triangle.cpp in Sources */,
 				9460B4C6204066D000DF2EE5 /* main.cpp in Sources */,

--- a/OpenGLAprendiendo/Triangle/Shaders/ShaderConstants.cpp
+++ b/OpenGLAprendiendo/Triangle/Shaders/ShaderConstants.cpp
@@ -1,0 +1,22 @@
+#include "ShaderConstants.hpp"
+
+// These are for iOS and use version 300 es
+
+const GLchar *VERTEX_SHADER = "#version 300 es\n"
+"layout (location = 0) in vec3 position;\n"
+"layout (location = 1) in vec3 aColor;\n"
+"out vec3 ourColor;\n"
+"void main()\n"
+"{\n"
+"   gl_Position = vec4(position.x, position.y, position.z, 1.0);\n"
+"   ourColor = aColor;\n"
+"}";
+
+const GLchar *FRAGMENT_SHADER = "#version 300 es\n"
+"precision mediump float;\n"
+"in vec3 ourColor;\n"
+"out vec4 FragColor;\n"
+"void main()\n"
+"{\n"
+"   FragColor = vec4(ourColor, 1.0);\n"
+"}";

--- a/OpenGLAprendiendo/Triangle/Shaders/ShaderConstants.hpp
+++ b/OpenGLAprendiendo/Triangle/Shaders/ShaderConstants.hpp
@@ -1,0 +1,20 @@
+#ifndef ShaderConstants_hpp
+#define ShaderConstants_hpp
+
+// Note: See "TargetConditionals.h" for TARGET information
+
+#ifdef __APPLE__
+    #include "TargetConditionals.h"
+
+    #if TARGET_OS_OSX
+        #include <GL/glew.h>
+    #else
+        #include <OpenGLES/ES3/glext.h>
+    #endif
+#endif
+
+
+extern const GLchar *VERTEX_SHADER;
+extern const GLchar *FRAGMENT_SHADER;
+
+#endif

--- a/OpenGLAprendiendo/Triangle/Shaders/ShaderManager.cpp
+++ b/OpenGLAprendiendo/Triangle/Shaders/ShaderManager.cpp
@@ -1,4 +1,5 @@
 #include "ShaderManager.hpp"
+#include "ShaderConstants.hpp"
 
 #include <iostream>
 #include <sstream>
@@ -37,6 +38,7 @@ void ShaderManager::loadShadersFromPaths(const GLchar *vertexPath, const GLchar 
     
     const GLchar *vShaderCode = vertexCode.c_str();
     const GLchar *fShaderCode = fragmentCode.c_str();
+    
     // 2. Compile shaders
     GLuint vertex, fragment;
     GLint success;
@@ -83,4 +85,52 @@ void ShaderManager::loadShadersFromPaths(const GLchar *vertexPath, const GLchar 
 void ShaderManager::useProgram()
 {
     glUseProgram(shaderProgram);
+}
+
+void ShaderManager::loadHardcodedShaders()
+{
+    const GLchar *vShaderCode = VERTEX_SHADER;
+    const GLchar *fShaderCode = FRAGMENT_SHADER;
+    
+    // 2. Compile shaders
+    GLuint vertex, fragment;
+    GLint success;
+    GLchar infoLog[512];
+    // Vertex Shader
+    vertex = glCreateShader(GL_VERTEX_SHADER);
+    glShaderSource(vertex, 1, &vShaderCode, NULL);
+    glCompileShader(vertex);
+    // Print compile errors if any
+    glGetShaderiv(vertex, GL_COMPILE_STATUS, &success);
+    if (!success)
+    {
+        glGetShaderInfoLog(vertex, 512, NULL, infoLog);
+        std::cout << "ERROR::SHADER::VERTEX::COMPILATION_FAILED\n" << infoLog << std::endl;
+    }
+    // Fragment Shader
+    fragment = glCreateShader(GL_FRAGMENT_SHADER);
+    glShaderSource(fragment, 1, &fShaderCode, NULL);
+    glCompileShader(fragment);
+    // Print compile errors if any
+    glGetShaderiv(fragment, GL_COMPILE_STATUS, &success);
+    if (!success)
+    {
+        glGetShaderInfoLog(fragment, 512, NULL, infoLog);
+        std::cout << "ERROR::SHADER::FRAGMENT::COMPILATION_FAILED\n" << infoLog << std::endl;
+    }
+    // Shader Program
+    shaderProgram = glCreateProgram();
+    glAttachShader(shaderProgram, vertex);
+    glAttachShader(shaderProgram, fragment);
+    glLinkProgram(shaderProgram);
+    // Print linking errors if any
+    glGetProgramiv(shaderProgram, GL_LINK_STATUS, &success);
+    if (!success)
+    {
+        glGetProgramInfoLog(shaderProgram, 512, NULL, infoLog);
+        std::cout << "ERROR::SHADER::PROGRAM::LINKING_FAILED\n" << infoLog << std::endl;
+    }
+    // Delete the shaders as they're linked into our program now and no longer necessery
+    glDeleteShader(vertex);
+    glDeleteShader(fragment);
 }

--- a/OpenGLAprendiendo/Triangle/Shaders/ShaderManager.hpp
+++ b/OpenGLAprendiendo/Triangle/Shaders/ShaderManager.hpp
@@ -1,7 +1,17 @@
 #ifndef Shader_hpp
 #define Shader_hpp
 
-#include <GL/glew.h>
+// Note: See "TargetConditionals.h" for TARGET information
+
+#ifdef __APPLE__
+    #include "TargetConditionals.h"
+
+    #if TARGET_OS_OSX
+        #include <GL/glew.h>
+    #else
+        #include <OpenGLES/ES3/glext.h>
+    #endif
+#endif
 
 class ShaderManager
 {

--- a/OpenGLAprendiendo/Triangle/Shaders/ShaderManager.hpp
+++ b/OpenGLAprendiendo/Triangle/Shaders/ShaderManager.hpp
@@ -18,6 +18,11 @@ class ShaderManager
 public:
     void loadShadersFromPaths(const GLchar *vertexPath, const GLchar *fragmentPath);
     
+    // This is so that I can load hardcoded shaders on iOS so that I don't have to deal
+    // with the filesystem right now.
+    
+    void loadHardcodedShaders();
+    
     // Uses the current shaders
     
     void useProgram();

--- a/OpenGLAprendiendo/Triangle/Shaders/vertex.glsl
+++ b/OpenGLAprendiendo/Triangle/Shaders/vertex.glsl
@@ -1,4 +1,4 @@
-# version 330 core
+#version 330 core
 
 layout (location = 0) in vec3 position;
 layout (location = 1) in vec3 aColor;

--- a/OpenGLAprendiendo/Triangle/Triangle.cpp
+++ b/OpenGLAprendiendo/Triangle/Triangle.cpp
@@ -1,10 +1,17 @@
 #include "Triangle.hpp"
 
-GLfloat triangleVertices[] = {
+GLfloat macOSTriangleVertices[] = {
     // positions          // colors
     0.5f, -0.5f, 0.0f,    1.0f, 0.0f, 0.0f,   // bottom right
     -0.5f, -0.5f, 0.0f,   0.0f, 1.0f, 0.0f,   // bottom left
     0.0f,  0.5f, 0.0f,    0.0f, 0.0f, 1.0f    // top
+};
+
+GLfloat triangleVertices[] = {
+    // positions          // colors
+    0.5f, -0.25f, 0.0f,     1.0f, 0.0f, 0.0f,   // bottom right
+    -0.5, -0.25, 0.0,       0.0f, 1.0f, 0.0f,   // bottom left
+    0.0, 0.25, 0.0,         0.0f, 0.0f, 1.0f    // top
 };
 
 Triangle::Triangle(GLboolean isMacOS)
@@ -31,8 +38,18 @@ void Triangle::setup()
     glBindVertexArray(VAO);
 
     glBindBuffer(GL_ARRAY_BUFFER, VBO);
-    glBufferData(GL_ARRAY_BUFFER, sizeof(triangleVertices), triangleVertices, GL_STATIC_DRAW);
+    
+    if(isMacOS)
+    {
+        glBufferData(GL_ARRAY_BUFFER, sizeof(macOSTriangleVertices), macOSTriangleVertices, GL_STATIC_DRAW);
 
+    }
+    else
+    {
+        glBufferData(GL_ARRAY_BUFFER, sizeof(macOSTriangleVertices), triangleVertices, GL_STATIC_DRAW);
+
+    }
+    
     // position attribute
 
     glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, 6 * sizeof(float), (void*)0);

--- a/OpenGLAprendiendo/Triangle/Triangle.cpp
+++ b/OpenGLAprendiendo/Triangle/Triangle.cpp
@@ -7,11 +7,21 @@ GLfloat triangleVertices[] = {
     0.0f,  0.5f, 0.0f,    0.0f, 0.0f, 1.0f    // top
 };
 
-Triangle::Triangle() {}
+Triangle::Triangle(GLboolean isMacOS)
+{
+    this->isMacOS = isMacOS;
+}
 
 void Triangle::setup()
 {
-    shaderManager.loadShadersFromPaths("vertex.glsl", "fragment.glsl");
+    if (isMacOS)
+    {
+        shaderManager.loadShadersFromPaths("vertex.glsl", "fragment.glsl");
+    }
+    else
+    {
+        shaderManager.loadHardcodedShaders();
+    }
     
     glGenVertexArrays(1, &VAO);
     glGenBuffers(1, &VBO);

--- a/OpenGLAprendiendo/Triangle/Triangle.cpp
+++ b/OpenGLAprendiendo/Triangle/Triangle.cpp
@@ -46,7 +46,7 @@ void Triangle::setup()
     }
     else
     {
-        glBufferData(GL_ARRAY_BUFFER, sizeof(macOSTriangleVertices), triangleVertices, GL_STATIC_DRAW);
+        glBufferData(GL_ARRAY_BUFFER, sizeof(triangleVertices), triangleVertices, GL_STATIC_DRAW);
 
     }
     

--- a/OpenGLAprendiendo/Triangle/Triangle.hpp
+++ b/OpenGLAprendiendo/Triangle/Triangle.hpp
@@ -8,13 +8,16 @@
 class Triangle
 {
 public:
-    Triangle();
+    // This constuctor exists to handle loading of the shaders differently if we are on macOS vs. iOS
+    
+    Triangle(GLboolean isMacOS = true);
     
     void setup();
     void teardown();
     void render();
     
 private:
+    GLboolean isMacOS;
     GLuint VAO;
     GLuint VBO;
     ShaderManager shaderManager;

--- a/OpenGLAprendiendo/main.cpp
+++ b/OpenGLAprendiendo/main.cpp
@@ -28,7 +28,7 @@ int main()
         return -1;
     }
 
-    Triangle triangle;
+    Triangle triangle(false);
     triangle.setup();
     
     // display loop

--- a/OpenGLAprendiendo/main.cpp
+++ b/OpenGLAprendiendo/main.cpp
@@ -28,7 +28,7 @@ int main()
         return -1;
     }
 
-    Triangle triangle(false);
+    Triangle triangle;
     triangle.setup();
     
     // display loop


### PR DESCRIPTION
Make this project just a tiny bit more cross platform by adding a toggle in the Triangle class called `isMacOS` that will compile and program link hardcoded OpenGL ES 3.0 shader files instead of the separate shader files when set to false.  It also includes `#ifdef __APPLE__` for more cross platform support for iOS in `ShaderConstants.hpp`.

This PR also includes a podspec file that will be used so that another macOS or iOS app can pull the Triangle class source.